### PR TITLE
adds flask-assets to manage static content

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,7 @@ constants_override.py
 
 # vim
 *.swp
+
+# Flask Assets
+static/.webassets-cache
+static/gen

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,8 +1,11 @@
 from flask import Flask
 from flask_babel import Babel
+from flask_assets import Environment, Bundle
+
 import urllib
 
 from config import constants
+
 
 class MyFlask(Flask):
     def get_send_file_max_age(self, name):
@@ -11,7 +14,28 @@ class MyFlask(Flask):
         return super(MyFlask, self).get_send_file_max_age(name)
 
 app = MyFlask(__name__,
-    template_folder=constants.TEMPLATE_ROOT,
-    static_folder=constants.STATIC_ROOT)
+              template_folder=constants.TEMPLATE_ROOT,
+              static_folder=constants.STATIC_ROOT)
+
+assets = Environment(app)
+
+js_all = Bundle("js/vendor-jquery-3.2.1.min.js",
+                "js/vendor-popper.min.js",
+                "js/vendor-bootstrap.min.js",
+                "js/alertify.js",
+                "js/script.js",
+                "js/wow.min.js",
+                filters=['jsmin', ],
+                output='gen/packed.js')
+
+css_all = Bundle("css/vendor-bootstrap-4.0.0-beta2.css",
+                 "css/style.css",
+                 "css/alertify.css",
+                 "css/animate.css",
+                 filters='cssmin',
+                 output='gen/packed.css')
+
+assets.register('js_all', js_all)
+assets.register('css_all', css_all)
 
 app.jinja_env.filters['quote_plus'] = lambda u: urllib.quote_plus(u.encode('utf8'))

--- a/app/app_config.py
+++ b/app/app_config.py
@@ -19,6 +19,7 @@ class AppConfig(object):
 def init_app(app):
     db.init_app(app)
 
+
 def init_prod_app(app):
     app.config.from_object(__name__ + '.AppConfig')
     init_app(app)

--- a/babel.cfg
+++ b/babel.cfg
@@ -1,3 +1,3 @@
 [python: **.py]
 [jinja2: **/templates/**.html]
-extensions=jinja2.ext.autoescape,jinja2.ext.with_
+extensions=jinja2.ext.autoescape,jinja2.ext.with_,webassets.ext.jinja2.AssetsExtension

--- a/config/constants.py
+++ b/config/constants.py
@@ -9,6 +9,8 @@ dotenv.load() or dotenv.load('.env')
 DEV_EMAIL = dotenv.get('DEV_EMAIL', default=None)
 
 DEBUG = dotenv.get('DEBUG', default=False)
+ASSET_DEBUG = dotenv.get('ASSET_DEBUG', default=DEBUG)
+
 
 HOST = dotenv.get('HOST')
 HTTPS = dotenv.get('HTTPS', default=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,9 +9,11 @@ cffi==1.11.4
 chardet==3.0.4
 click==6.7
 cryptography==2.1.4
+cssmin==0.2.0
 decorator==4.2.1
 enum34==1.1.6
 Flask==0.12.2
+Flask-Assets==0.12
 Flask-Babel==0.11.2
 Flask-Compress==1.4.0
 Flask-Migrate==2.1.1
@@ -25,6 +27,7 @@ ipython==5.5.0
 ipython-genutils==0.2.0
 itsdangerous==0.24
 Jinja2==2.10
+jsmin==2.2.2
 MarkupSafe==1.0
 newrelic
 path.py==10.5

--- a/templates/base.html
+++ b/templates/base.html
@@ -19,7 +19,10 @@
     {% block styles %}
       {# The biggest delay to rendering the site is the google fonts, so we make sure it is the first to start loading #}
       <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Lato:300,400,500|Poppins:200,300,400,500"/>  
-      <link rel="stylesheet" href="/static/css/all_styles.css"/>
+      {% assets "css_all" %}
+        <link rel="stylesheet" href="{{ ASSET_URL }}"/>
+      {% endassets %}
+      
       <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.0.6/css/all.css" media="all"/>
 
       <!-- Favicons generated with https://realfavicongenerator.net/ -->
@@ -47,7 +50,9 @@
     {% endblock %}
 
     {% block scripts %}
-      <script src="/static/js/all_javascript.js"></script>
+      {% assets "js_all" %}
+        <script type="text/javascript" src="{{ ASSET_URL }}"></script>
+      {% endassets %}
       <script>
       new WOW().init();
       </script>

--- a/views/web_views.py
+++ b/views/web_views.py
@@ -165,25 +165,6 @@ def partners_interest():
     flash(feedback)
     return jsonify("OK")
 
-@app.route('/static/css/all_styles.css')
-def assets_all_styles():
-    return Response(concat_asset_files([
-        "static/css/vendor-bootstrap-4.0.0-beta2.css",
-        "static/css/style.css",
-        "static/css/alertify.css",
-        "static/css/animate.css"
-    ]), mimetype="text/css")
-
-@app.route('/static/js/all_javascript.js')
-def assets_all_javascript():
-    return Response(concat_asset_files([
-        "static/js/vendor-jquery-3.2.1.min.js",
-        "static/js/vendor-popper.min.js",
-        "static/js/vendor-bootstrap.min.js",
-        "static/js/alertify.js",
-        "static/js/script.js",
-        "static/js/wow.min.js"
-    ]), mimetype="application/javascript")
 
 @app.context_processor
 def inject_partners():


### PR DESCRIPTION
Initial setup for packaging static content via flask-assets.
Will be able to use babel and dependent presets to write es6 code. Also, minification and any other packaging needs are handled easily.

Integrates very well with flask-cdn and uses MD5 hashes of files to invalidate cachces, if in future we opt to use a CDN.