### PR TITLE
Add templates for CoinList investment period email

### DIFF
--- a/logic/emails/email_types.py
+++ b/logic/emails/email_types.py
@@ -36,6 +36,9 @@ EMAILS = {
     },
     'coinlist_reminder': {
         'subject': 'Registration ending soon for Origin\'s CoinList round'
+    },
+    'coinlist_investment_period': {
+        'subject': 'Investment Period Has Started For Origin\'s CoinList Round'
     }
 }
 

--- a/templates/email/coinlist_investment_period.html
+++ b/templates/email/coinlist_investment_period.html
@@ -1,0 +1,54 @@
+{% extends 'email/email_base.html' %}
+
+{% block content %}
+
+<table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%">
+  <tr>
+    <td style="padding: 40px; font-family: 'Lato', sans-serif; font-size: 15px; line-height: 20px; color: #444444;">
+
+It is a big day at Origin!
+
+<br><br>
+
+We are excited to be working with one of the biggest names in our industry for our <a href="https://coinlist.co/origin">CoinList Round of funding</a>. We had a short ten-day registration period that ended last night, and we’ve amassed over 7,000 interested investors requesting over $125M in allocations. If you applied as an accredited investor in the past 10 days and were accepted through CoinList’s verification process now is your time (or, in just a few minutes) to log into <a href="https://coinlist.co/origin">https://coinlist.co/origin</a> to see your allocation and instructions for funding. <span style="font-weight: bold;">The investment period starts today at 9am PST (GMT-7) and lasts until the round is full.</span> We’ve structured the round to give investors time to confirm their investments, but it’s still possible the round will fill quickly. Please don’t delay with logging in and confirming your allocation.
+
+<br><br>
+
+<a href="https://www.coinlist.co/origin">
+<img src='http://www.originprotocol.com/static/img/coinlist.png' width='100%'/>
+</a>
+
+<br><br>
+
+Our goal is to maximize the amount of participants, so we are going about this round of fundraising a little differently. To learn more about how we chose our maximum allocation amount and what to expect during the investment period, check out our recent post on Medium.
+  
+<br><br>
+
+<table width="100%" border="0" cellspacing="0" cellpadding="0">
+  <tr>
+    <td>
+      <table border="0" cellspacing="0" cellpadding="0">
+        <tr>
+          <td align="center" style="border-radius: 6px;" bgcolor="#1a82ff">
+            <a href="https://medium.com/originprotocol/investment-period-has-begun-for-origins-coinlist-round-2b9683197c29" target="_blank" style="font-size: 16px; font-family: 'Lato', 'Helvetica Neue', 'Arial', sans-serif; color: #ffffff; text-decoration: none; text-decoration: none;border-radius: 6px; padding: 12px 18px; border: 1px solid #1a82ff; display: inline-block;">READ MORE</a>
+          </td>
+        </tr>
+      </table>
+    </td>
+  </tr>
+</table>
+
+<br><br>
+
+Not an accredited investor or didn’t register in time? Don’t worry, we are building world class technology that will change how the sharing economy works. We have not announced anything beyond the CoinList Round, but if we do it will be through our <a href="https://www.originprotocol.com">Website</a>, <a href="https://medium.com/originprotocol">Medium</a>, <a href="https://t.me/originprotocol">Telegram</a> and <a href="https://www.youtube.com/channel/UCXYiy1W17wY8VafpzF8TwBA?sub_confirmation=1">YouTube</a>.
+
+<br><br>
+
+<span style="color: #ff1a1a; font-weight: bold;">PLEASE BEWARE OF SCAMMERS</span>. Do NOT send ETH or BTC to any addresses shown in Telegram as scammers are likely to attack at this time. CoinList will provide funding instructions on their website: <a href="https://coinlist.co/origin">https://coinlist.co/origin</a>
+
+    </td>
+  </tr>
+</table>
+  
+{% endblock %}
+

--- a/templates/email/coinlist_investment_period.txt
+++ b/templates/email/coinlist_investment_period.txt
@@ -1,0 +1,17 @@
+{% extends 'email/email_base.txt' %}
+
+{% block content %}
+
+It is a big day at Origin!
+
+We are excited to be working with one of the biggest names in our industry for our CoinList Round of funding (https://coinlist.co/origin). We had a short ten-day registration period that ended last night, and we’ve amassed over 7,000 interested investors requesting over $125M in allocations. If you applied as an accredited investor in the past 10 days and were accepted through CoinList’s verification process now is your time (or, in just a few minutes) to log into https://coinlist.co/origin to see your allocation and instructions for funding. The investment period starts today at 9am PST (GMT-7) and lasts until the round is full. We’ve structured the round to give investors time to confirm their investments, but it’s still possible the round will fill quickly. Please don’t delay with logging in and confirming your allocation.
+
+Our goal is to maximize the amount of participants, so we are going about this round of fundraising a little differently. To learn more about how we chose our maximum allocation amount and what to expect during the investment period, check out our recent post on Medium.
+
+Read more (https://medium.com/originprotocol/investment-period-has-begun-for-origins-coinlist-round-2b9683197c29)
+
+Not an accredited investor or didn’t register in time? Don’t worry, we are building world class technology that will change how the sharing economy works. We have not announced anything beyond the CoinList Round, but if we do it will be through our Website (https://www.originprotocol.com), Medium (https://medium.com/originprotocol), Telegram (https://t.me/originprotocol) and YouTube (https://www.youtube.com/channel/UCXYiy1W17wY8VafpzF8TwBA?sub_confirmation=1).
+
+PLEASE BEWARE OF SCAMMERS. Do NOT send ETH or BTC to any addresses shown in Telegram as scammers are likely to attack at this time. CoinList will provide funding instructions on their website: https://coinlist.co/origin 
+{% endblock %}
+


### PR DESCRIPTION
This adds the `.html` and `.txt` templates for the next CoinList email. I have not tested this by sending any emails but have deployed the styled version as [a page on my Heroku instance](https://originprotocol-com-micah.herokuapp.com/email). Other than testing with emails, the main thing left to do is to publish Jon's Medium post and confirm the link.