### PR TITLE
Make announcement banner reactive

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -197,7 +197,7 @@ a:hover {
   line-height: 1;
 }
 
-.registration-arrow {
+#registration-arrow {
   border-bottom: 9px solid transparent;
   border-left: 12px solid #cc7cbc;
   border-top: 9px solid transparent;
@@ -207,7 +207,7 @@ a:hover {
   width: 0;
 }
 
-#rtl .registration-arrow {
+#rtl #registration-arrow {
   border-left: 0;
   border-right: 12px solid #cc7cbc;
 }
@@ -2090,7 +2090,7 @@ footer .company-mission {
     margin: 0 0 0 20px;
     padding: 0 0 0 20px;
   }
-  .announcement .container .registration-arrow {
+  .announcement .container #registration-arrow {
     display: block;
     margin: 0 20px;
   }
@@ -2110,7 +2110,7 @@ footer .company-mission {
     margin-right: 0;
   }
   #rtl .announcement .container > .registration-alert,
-  #rtl .announcement .container > .registration-arrow {
+  #rtl .announcement .container > #registration-arrow {
     margin-left: 20px;
   }
   .navbar .container {

--- a/templates/announcement.html
+++ b/templates/announcement.html
@@ -1,35 +1,89 @@
 <div id="announcement" class="announcement">
   <div class="d-flex flex-wrap align-items-center container justify-content-between">
-    <div class="img-container d-flex align-items-center order-md-0">
+    <div class="img-container d-flex align-items-center">
       <a href="https://www.coinlist.co/origin">
         <img src="/static/img/coinlist-logo.png"
         srcset="/static/img/coinlist-logo@2x.png 2x, /static/img/coinlist-logo@3x.png 3x"
         role="presentation" />
       </a>
     </div>
-    <div class="message order-md-2 order-lg-1">
+    <div class="message">
       <h1>CoinList <span class="subdued">Round</span></h1>
-      <h2><strong>{{ gettext("Register today!") }}</strong> {{ gettext("$1,000 minimum.") }} {{ gettext("Availability limited.") }} <a href="https://medium.com/originprotocol/origins-next-funding-round-now-live-on-coinlist-147096f6a906" target="_blank" class="d-lg-block d-xl-inline">{{ gettext("Learn more.") }}</a></h2>
+      <h2 class="d-none stage-1"><strong>{{ gettext("Register today!") }}</strong> {{ gettext("$1,000 minimum.") }} {{ gettext("Availability limited.") }} <a href="https://medium.com/originprotocol/origins-next-funding-round-now-live-on-coinlist-147096f6a906" target="_blank" class="d-lg-block d-xl-inline">{{ gettext("Learn more.") }}</a></h2>
+      <h2 class="d-none stage-2"><a href="https://medium.com/originprotocol/origins-next-funding-round-now-live-on-coinlist-147096f6a906" target="_blank" class="d-lg-block d-xl-inline">{{ gettext("Learn more.") }}</a></h2>
+      <h2 class="d-none stage-3"><strong>{{ gettext("Investment period is now open!") }}</strong> <a href="https://medium.com/originprotocol/investment-period-has-begun-for-origins-coinlist-round-2b9683197c29" target="_blank" class="d-lg-block d-xl-inline">{{ gettext("Learn more.") }}</a></h2>
     </div>
-    <div class="registration-alert order-md-1 order-lg-2">
-      <header>{{ gettext("Registration Ends In") }}</header>
-      <div id="countdown">
+    <div class="registration-alert">
+      <header class="d-none stage-1">{{ gettext("Registration Ends In") }}</header>
+      <header class="d-none stage-2">{{ gettext("Sale Starts In") }}</header>
+      <header class="d-none stage-3">{{ gettext("Sale Ends Soon") }}</header>
+      <div id="countdown" class="d-none">
         <span class="days"></span>d
         <span class="hours"></span>h
         <span class="minutes"></span>m
         <span class="seconds"></span>s
       </div>
     </div>
-    <div class="registration-arrow order-md-3">
+    <div id="registration-arrow" class="d-none">
     </div>
-    <div class="link-container order-md-4">
-      <a href="http://coinlist.co/origin" target="_blank" class="registration-button">{{ gettext("Register Now") }}</a>
+    <div class="link-container">
+      <a href="http://coinlist.co/origin" target="_blank" class="d-none stage-1 registration-button">{{ gettext("Register Now") }}</a>
+      <a href="http://coinlist.co/origin" target="_blank" class="d-none stage-3 registration-button">{{ gettext("See On CoinList") }}</a>
     </div>
   </div>
 </div>
 
 {% block extra_scripts %}
 <script type="text/javascript">
+  // end of day (PDT) on June 27, 2018
+  const endOfRegistration = new Date('2018-06-28T06:59:59.999Z');
+  // 9:00 am (PDT) on June 28, 2018
+  const endOfLimbo = new Date('2018-06-28T15:59:59.999Z');
+  // 6:00 pm (PDT) on July 3, 2018
+  const endOfSale = new Date('2018-07-04T00:59:59.999Z');
+
+  let currentDeadline;
+
+  const calculateDeadline = () => {
+    const currentTime = new Date();
+
+    // during registration period
+    if (currentTime <= endOfRegistration) {
+      initTimer('countdown', endOfRegistration);
+
+      [...document.querySelectorAll('.stage-1')].forEach(el => el.classList.remove('d-none'));
+      [...document.querySelectorAll('.stage-2')].forEach(el => el.classList.add('d-none'));
+      [...document.querySelectorAll('.stage-3')].forEach(el => el.classList.add('d-none'));
+
+      document.getElementById('countdown').classList.remove('d-none');
+      document.getElementById('registration-arrow').classList.remove('d-none');
+    // during limbo
+    } else if (currentTime <= endOfLimbo) {
+      initTimer('countdown', endOfLimbo);
+
+      [...document.querySelectorAll('.stage-1')].forEach(el => el.classList.add('d-none'));
+      [...document.querySelectorAll('.stage-2')].forEach(el => el.classList.remove('d-none'));
+      [...document.querySelectorAll('.stage-3')].forEach(el => el.classList.add('d-none'));
+
+      document.getElementById('countdown').classList.remove('d-none');
+      document.getElementById('registration-arrow').classList.add('d-none');
+    // during sale
+    } else if (currentTime <= endOfSale) {
+      initTimer('countdown', endOfSale);
+
+      [...document.querySelectorAll('.stage-1')].forEach(el => el.classList.add('d-none'));
+      [...document.querySelectorAll('.stage-2')].forEach(el => el.classList.add('d-none'));
+      [...document.querySelectorAll('.stage-3')].forEach(el => el.classList.remove('d-none'));
+
+      document.getElementById('countdown').classList.add('d-none');
+      document.getElementById('registration-arrow').classList.remove('d-none');
+    // after all
+    } else {
+      currentDeadline = currentTime;
+
+      document.getElementById('announcement').classList.add('d-none');
+    }
+  };
 
   const timeRemaining = (end) => {
     const total = Date.parse(end) - Date.parse(new Date());
@@ -39,7 +93,7 @@
     const days = Math.floor(total / (1000 * 60 * 60 * 24));
 
     return { total, days, hours, minutes, seconds };
-  }
+  };
 
   const initTimer = (id, end) => {
 
@@ -59,17 +113,16 @@
 
       if (t.total <= 0) {
         clearInterval(int);
+
+        calculateDeadline();
       }
-    }
+    };
 
     const int = setInterval(update, 1000);
 
     update();
-  }
+  };
 
-    // end of day (PDT) on June 27, 2018
-    const deadline = new Date('2018-06-28T06:59:59.999Z');
-
-    initTimer('countdown', deadline);
-  </script>
-  {% endblock %}
+  calculateDeadline();
+</script>
+{% endblock %}


### PR DESCRIPTION
This causes the CoinList announcement banner to change its state upon the expiration of each deadline. The code is not particularly pretty, and it probably isn't bulletproof. One thing that should be done is confirm that the new Medium post link will be accurate once it is published. This also hides the banner after the sale has officially ended, although we should probably deploy a new version before then if the sale is cut off early due to demand. We will also want to put the phishing warning back up at that point.