### PR TITLE
Developer page hashtag-able links

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1793,6 +1793,20 @@ footer .company-mission {
   visibility: visible;
 }
 
+#rtl .header-link {
+  padding-left: 0;
+  padding-right: 1em;
+  margin-left: 0;
+  margin-right: -1em;
+}
+
+#rtl .header-text .header-link i {
+  margin-left: 0;
+  margin-right: -1.5em;
+  padding-left: .5em;
+  padding-right: 0;
+}
+
 /* xs */
 @media (max-width: 575px) {
   .btn,

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1771,14 +1771,14 @@ footer .company-mission {
 }
 
 .header-text .header-link {
-  padding-left: .65em;
-  margin-left: -.65em;
+  padding-left: 1em;
+  margin-left: -1em;
 }
 
 .header-text .header-link i {
   visibility: hidden;
-  margin-left: -1.25em;
-  padding-right: .25em;
+  margin-left: -1.5em;
+  padding-right: .5em;
   font-size: 15px;
   -webkit-transition: opacity 0.2s ease-in-out 0.1s;
   -moz-transition: opacity 0.2s ease-in-out 0.1s;

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1770,23 +1770,18 @@ footer .company-mission {
   text-decoration: underline;
 }
 
-.header-link {
-  position: absolute;
-  left: -0.7em;
-  opacity: 0;
+.header-text .header-link {
+  visibility: hidden;
+  margin-left: -1.25em;
+  padding-right: .25em;
+  -webkit-transition: opacity 0.2s ease-in-out 0.1s;
+  -moz-transition: opacity 0.2s ease-in-out 0.1s;
+  -ms-transition: opacity 0.2s ease-in-out 0.1s;
+}  
 
-  \-webkit-transition: opacity 0.2s ease-in-out 0.1s;
-  \-moz-transition: opacity 0.2s ease-in-out 0.1s;
-  \-ms-transition: opacity 0.2s ease-in-out 0.1s;
-}
-
-h2:hover .header-link,
-h3:hover .header-link,
-h4:hover .header-link,
-h5:hover .header-link,
-h6:hover .header-link {
-  opacity: 1;
-}
+.header-text:hover .header-link {
+  visibility: visible;
+} 
 
 /* xs */
 @media (max-width: 575px) {

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1770,6 +1770,11 @@ footer .company-mission {
   text-decoration: underline;
 }
 
+.header-text .header-link {
+  padding-left: .65em;
+  margin-left: -.65em;
+}
+
 .header-text .header-link i {
   visibility: hidden;
   margin-left: -1.25em;

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1770,10 +1770,29 @@ footer .company-mission {
   text-decoration: underline;
 }
 
+/*.header-text .header-link {
+  visibility: hidden;
+  position: absolute;
+  font-size: 15px;
+  top: 1.5em;
+  left: -.5em;
+  padding-right: 1.5em;
+  -webkit-transition: opacity 0.2s ease-in-out 0.1s;
+  -moz-transition: opacity 0.2s ease-in-out 0.1s;
+  -ms-transition: opacity 0.2s ease-in-out 0.1s;
+}  
+
+.header-text:hover .header-link {
+  visibility: visible;
+} */
+
+
+/* old css */
 .header-text .header-link {
   visibility: hidden;
   margin-left: -1.25em;
   padding-right: .25em;
+  font-size: 15px;
   -webkit-transition: opacity 0.2s ease-in-out 0.1s;
   -moz-transition: opacity 0.2s ease-in-out 0.1s;
   -ms-transition: opacity 0.2s ease-in-out 0.1s;

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1770,6 +1770,24 @@ footer .company-mission {
   text-decoration: underline;
 }
 
+.header-link {
+  position: absolute;
+  left: -0.5em;
+  opacity: 0;
+
+  \-webkit-transition: opacity 0.2s ease-in-out 0.1s;
+  \-moz-transition: opacity 0.2s ease-in-out 0.1s;
+  \-ms-transition: opacity 0.2s ease-in-out 0.1s;
+}
+
+h2:hover .header-link,
+h3:hover .header-link,
+h4:hover .header-link,
+h5:hover .header-link,
+h6:hover .header-link {
+  opacity: 1;
+}
+
 /* xs */
 @media (max-width: 575px) {
   .btn,

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1772,7 +1772,7 @@ footer .company-mission {
 
 .header-link {
   position: absolute;
-  left: -0.5em;
+  left: -0.7em;
   opacity: 0;
 
   \-webkit-transition: opacity 0.2s ease-in-out 0.1s;

--- a/static/js/script.js
+++ b/static/js/script.js
@@ -102,7 +102,7 @@ $(function() {
     var $el, icon, id;
     $el = $(el);
     id = $el.attr('id');
-    icon = '<i class="fa fa-link"></i>';
+    icon = '<i class="fas fa-link"></i>';
     if (id) {
       return $el.prepend($("<a />").addClass("header-link").attr("href", "#" + id).html(icon));
     }

--- a/static/js/script.js
+++ b/static/js/script.js
@@ -95,16 +95,3 @@ $(function() {
 $(function () {
   $('[data-toggle="tooltip"]').tooltip();
 })
-
-// Show header deep link icon on heading hover
-$(function() {
-  return $("h2, h3, h4, h5, h6").each(function(i, el) {
-    var $el, icon, id;
-    $el = $(el);
-    id = $el.attr('id');
-    icon = '<i class="fas fa-link"></i>';
-    if (id) {
-      return $el.prepend($("<a />").addClass("header-link").attr("href", "#" + id).html(icon));
-    }
-  });
-});

--- a/static/js/script.js
+++ b/static/js/script.js
@@ -95,3 +95,16 @@ $(function() {
 $(function () {
   $('[data-toggle="tooltip"]').tooltip();
 })
+
+// Show header deep link icon on heading hover
+$(function() {
+  return $("h2, h3, h4, h5, h6").each(function(i, el) {
+    var $el, icon, id;
+    $el = $(el);
+    id = $el.attr('id');
+    icon = '<i class="fa fa-link"></i>';
+    if (id) {
+      return $el.prepend($("<a />").addClass("header-link").attr("href", "#" + id).html(icon));
+    }
+  });
+});

--- a/templates/developers.html
+++ b/templates/developers.html
@@ -89,7 +89,7 @@
         <div class="container foreground-content">
           <div class="row">
             <div class="col-12 col-md-6">
-                <h2 class="header-text" id="involved"><a class="header-link" href="#involved"><i class="fas fa-link"></i></a>How To Get Involved</h2>
+              <h2 class="header-text" id="involved"><a class="header-link" href="#involved"><i class="fas fa-link"></i></a>How To Get Involved</h2>
               <p>Our company is built upon a culture of radical inclusion and transparency. Everyone is welcome to participate in our open-source engineering process and our product discussions, which are public by default.</p>
               <p>
                 <strong>#1</strong>&nbsp;

--- a/templates/developers.html
+++ b/templates/developers.html
@@ -58,7 +58,7 @@
               </div>
             </div>
             <div class="col-12 col-md-6 order-1 order-md-2">
-              <h2>What We Are Building</h2>
+              <h2 id="building">What We Are Building</h2>
               <p>
                 <strong><a href="https://github.com/OriginProtocol/origin-js" target="blank">Origin.js</a> - </strong>
                 a library of Javascript code and Ethereum smart contracts which allow anyone to create decentralized marketplaces by calling simple API methods
@@ -150,8 +150,8 @@
   <section class="resources-section">
     <div class="container foreground-content">
       <div class="row">
-        <div id="resources" class="col-12">
-          <h2>Resources</h2>
+        <div class="col-12">
+          <h2 id="resources">Resources</h2>
         </div>
         <div class="col-12 col-lg-4">
           <h3 id="documentation">Documentation</h3>

--- a/templates/developers.html
+++ b/templates/developers.html
@@ -72,7 +72,7 @@
                 an endpoint enabling functionality that is either impossible or impractical to do directly on-chain, such as indexing, identity attestations, and notifications
               </p>
               <div class="btn-container">
-                <a href="https://github.com/OriginProtocol/" role="button" target="_blank" class="repos-btn btn btn-primary btn-min-size">
+                <a id="repos" href="https://github.com/OriginProtocol/" role="button" target="_blank" class="repos-btn btn btn-primary btn-min-size">
                   <i class='fab fa-github'></i>
                   Visit Repositories
                 </a>
@@ -89,7 +89,7 @@
         <div class="container foreground-content">
           <div class="row">
             <div class="col-12 col-md-6">
-              <h2>How To Get Involved</h2>
+              <h2 id="contributing">How To Get Involved</h2>
               <p>Our company is built upon a culture of radical inclusion and transparency. Everyone is welcome to participate in our open-source engineering process and our product discussions, which are public by default.</p>
               <p>
                 <strong>#1</strong>&nbsp;
@@ -150,11 +150,11 @@
   <section class="resources-section">
     <div class="container foreground-content">
       <div class="row">
-        <div class="col-12">
+        <div id="resources" class="col-12">
           <h2>Resources</h2>
         </div>
         <div class="col-12 col-lg-4">
-          <h3>Documentation</h3>
+          <h3 id="documentation">Documentation</h3>
           <p>
             Our docs describe <a href="http://docs.originprotocol.com/#contributing" target="_blank">how to contribute</a>, <a href="http://docs.originprotocol.com/#getting-started" target="_blank">using Origin.js in your project</a>, Origin's overall <a href="http://docs.originprotocol.com/#architecture" target="_blank">architecture</a>, and much more.
           </p>
@@ -166,8 +166,7 @@
           </div>
         </div>
         <div class="col-12 col-lg-4">
-          <h3>Weekly Engineering Call
-          </h3>
+          <h3 id="call">Weekly Engineering Call</h3>
           <p>
             Tune in to our public <a href="https://meet.google.com/pws-cgyd-tqp" target="_blank">Google Hangout</a> every Wednesday at 1PM PT, where we provide updates on our engineering progress and discuss upcoming features.
           </p>
@@ -179,7 +178,7 @@
           </div>
         </div>
         <div class="col-12 col-lg-4">
-          <h3>Discord</h3>
+          <h3 id="discord">Discord</h3>
           <p>Join our public Discord group (and specifically the #engineering channel) to become involved and contribute to our open source community.</p>
           <div class="btn-container">
             <a href="{{ universal.DISCORD_URL }}" role="button" class="discord-btn btn btn-outline-primary btn-min-size" target="_blank">

--- a/templates/developers.html
+++ b/templates/developers.html
@@ -58,7 +58,7 @@
               </div>
             </div>
             <div class="col-12 col-md-6 order-1 order-md-2">
-              <h2 id="building">What We Are Building</h2>
+              <h2 class="header-text" id="building"><a class="header-link" href="#building"><i class="fas fa-link"></i></a>What We Are Building</h2>
               <p>
                 <strong><a href="https://github.com/OriginProtocol/origin-js" target="blank">Origin.js</a> - </strong>
                 a library of Javascript code and Ethereum smart contracts which allow anyone to create decentralized marketplaces by calling simple API methods
@@ -89,7 +89,7 @@
         <div class="container foreground-content">
           <div class="row">
             <div class="col-12 col-md-6">
-              <h2 id="contributing">How To Get Involved</h2>
+                <h2 class="header-text" id="involved"><a class="header-link" href="#involved"><i class="fas fa-link"></i></a>How To Get Involved</h2>
               <p>Our company is built upon a culture of radical inclusion and transparency. Everyone is welcome to participate in our open-source engineering process and our product discussions, which are public by default.</p>
               <p>
                 <strong>#1</strong>&nbsp;
@@ -151,10 +151,10 @@
     <div class="container foreground-content">
       <div class="row">
         <div class="col-12">
-          <h2 id="resources">Resources</h2>
+          <h2 class="header-text" id="resources"><a class="header-link" href="#resources"><i class="fas fa-link"></i></a>Resources</h2>
         </div>
         <div class="col-12 col-lg-4">
-          <h3 id="documentation">Documentation</h3>
+          <h3 class="header-text" id="documentation"><a class="header-link" href="#documentation"><i class="fas fa-link"></i></a>Documentation</h3>
           <p>
             Our docs describe <a href="http://docs.originprotocol.com/#contributing" target="_blank">how to contribute</a>, <a href="http://docs.originprotocol.com/#getting-started" target="_blank">using Origin.js in your project</a>, Origin's overall <a href="http://docs.originprotocol.com/#architecture" target="_blank">architecture</a>, and much more.
           </p>
@@ -166,7 +166,7 @@
           </div>
         </div>
         <div class="col-12 col-lg-4">
-          <h3 id="call">Weekly Engineering Call</h3>
+          <h3 class="header-text" id="call"><a class="header-link" href="#call"><i class="fas fa-link"></i></a>Weekly Engineering Call</h3>
           <p>
             Tune in to our public <a href="https://meet.google.com/pws-cgyd-tqp" target="_blank">Google Hangout</a> every Wednesday at 1PM PT, where we provide updates on our engineering progress and discuss upcoming features.
           </p>
@@ -178,7 +178,7 @@
           </div>
         </div>
         <div class="col-12 col-lg-4">
-          <h3 id="discord">Discord</h3>
+          <h3 class="header-text" id="discord"><a class="header-link" href="#discord"><i class="fas fa-link"></i></a>Discord</h3>
           <p>Join our public Discord group (and specifically the #engineering channel) to become involved and contribute to our open source community.</p>
           <div class="btn-container">
             <a href="{{ universal.DISCORD_URL }}" role="button" class="discord-btn btn btn-outline-primary btn-min-size" target="_blank">


### PR DESCRIPTION
### Checklist:

- [x] Test your work and double check you didn't break anything
- [ ] Update the README, if neccessary

### Description:

- added hashtag-able deep links on all headings besides H1 (currently only on "Developers" page)
- headings require ID's to be set in order to trigger the anchor element/link icon when the heading is hovered
- this functionality is current global as I thought it may be useful on other parts of the site