### PR TITLE
Reduce likelihood of triangle overlapping features text

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -2355,6 +2355,9 @@ footer .company-mission {
   .navbar-origin .navbar-collapse .nav-item.dropdown {
     padding: 20px 30px;
   }
+  .technology-section .container-fluid > .row {
+    padding-bottom: 200px;
+  }
 }
 
 /* firefox hacks */


### PR DESCRIPTION
This adds some vertical spacing to the technology section on XL screens and prevents the grey triangle from overlapping the features text on reasonably-sized screens. 🤷‍♂️