### PR TITLE
Twitter card support.

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -7,7 +7,7 @@
     <meta name="description" content="{% block meta_description %}{% endblock %}">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=0"/>
 
-    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:site" content="@originprotocol" />
     <meta property="og:url" content="https://www.originprotocol.com"/>
     <meta property="og:image" content="https://www.originprotocol.com/static/img/fb-og-img.png"/>

--- a/templates/base.html
+++ b/templates/base.html
@@ -7,6 +7,8 @@
     <meta name="description" content="{% block meta_description %}{% endblock %}">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=0"/>
 
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:site" content="@originprotocol" />
     <meta property="og:url" content="https://www.originprotocol.com"/>
     <meta property="og:image" content="https://www.originprotocol.com/static/img/fb-og-img.png"/>
     <meta property="og:locale" content="{{ CURRENT_LANGUAGE }}"/>


### PR DESCRIPTION
This PR adds support for Twitter Cards and fixes #243

Note that I took advantage [of the feature of Twitter Cards](https://developer.twitter.com/en/docs/tweets/optimize-with-cards/guides/getting-started#twitter-cards-and-open-graph) (at the bottom of that page) that allows you to create Cards without duplicating tags and data.

I don't have ngrok set up in my python dev environment yet, so I previewed the Card using the [validator](https://cards-dev.twitter.com/validator) with a static HTML file I uploaded to a different server. Ignore the blocked out domain on this preview:

<img width="524" alt="screenshot 2018-07-12 20 28 09" src="https://user-images.githubusercontent.com/242736/42667629-52340b14-8612-11e8-9f84-6b953315431a.png">

If necessary, we can set separate description tags for Twitter Cards. Currently, it just defaults to the same OG stuff.

Thanks!