### PR TITLE
Update templates for Heroku

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,9 +90,9 @@ We use [Flask Migrate](https://flask-migrate.readthedocs.io/en/latest/) to handl
 
 To deploy a development copy of the site on Heroku, just choose which branch you would like to use and follow the instructions:
 
-| `Master` branch <br>(stable) | `Develop` branch<br> (active development) |
+| Release tag `v1.11.1` <br>(stable) | `Master` branch<br> (active development) |
 |---------|----------|
-| [![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/originprotocol/origin-website/tree/master) | [![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/originprotocol/origin-website/tree/develop) |
+| [![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/originprotocol/origin-website/tree/v1.11.1) | [![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/originprotocol/origin-website/tree/master) |
 
 Heroku will prompt you to set config variables. At a minium, you must set these two:
 

--- a/README.md
+++ b/README.md
@@ -90,9 +90,9 @@ We use [Flask Migrate](https://flask-migrate.readthedocs.io/en/latest/) to handl
 
 To deploy a development copy of the site on Heroku, just choose which branch you would like to use and follow the instructions:
 
-| Release tag `v1.11.1` <br>(stable) | `Master` branch<br> (active development) |
+| `stable` branch <br>(v1.11.1) | `master` branch<br> (active development) |
 |---------|----------|
-| [![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/originprotocol/origin-website/tree/v1.11.1) | [![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/originprotocol/origin-website/tree/master) |
+| [![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/originprotocol/origin-website/tree/stable) | [![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/originprotocol/origin-website/tree/master) |
 
 Heroku will prompt you to set config variables. At a minium, you must set these two:
 


### PR DESCRIPTION
As a dry run to prepare for consolidating the branches in the product-related repos, and in an effort to make this one confirm to the same branching strategy, I've done the following:

- [tagged the last commit](https://github.com/OriginProtocol/origin-website/tree/v1.11.1) with a somewhat arbitrary number (we can change at any time) - roughly approximated by how many significant features I noticed looking through the commit history
- updated [the one non-Crowdin PR](https://github.com/OriginProtocol/origin-website/pull/264) that had `develop` as its base - Stan will edit the Crowdin integration
- proposed here to update the README to use the tag for the stable Heroku template and `master` for the one under active development