### PR TITLE
Footer quick fix - capitalize H in "GitHub"

### DIFF
--- a/templates/footer.html
+++ b/templates/footer.html
@@ -53,7 +53,7 @@
               </li>
               <li class="footer-link">
                 <a href="https://github.com/OriginProtocol" target="_blank">
-                  {{ gettext("Github") }}
+                  {{ gettext("GitHub") }}
                 </a>
               </li>
               <li class="footer-link">


### PR DESCRIPTION
First pull request? Read our [guide to contributing](https://docs.originprotocol.com/#contributing)

### Checklist:

- [ x ] Test your work and double check you didn't break anything
~~- [ ] Update the README, if neccessary~~

### Description:

In the footer, capitalized "H" in GitHub. Mimics DApp footer. 