### PR TITLE
Remove but support '/en' in website URL

### DIFF
--- a/config/constants.py
+++ b/config/constants.py
@@ -43,6 +43,8 @@ GITHUB_KEY = dotenv.get('GITHUB_KEY')
 
 # Language option constants
 
+DEFAULT_LANGUAGES = ['en', 'en_US', 'en_GB']
+
 LANGUAGES = [
     'ar',
     'de',

--- a/views/web_views.py
+++ b/views/web_views.py
@@ -42,7 +42,11 @@ def beforeRequest():
 
 @app.route('/')
 def root():
-    return redirect(url_for('index', lang_code=get_locale()))
+    locale = get_locale()
+    if locale and locale in constants.DEFAULT_LANGUAGES:
+        return render_template('index.html')
+    else:
+        return redirect(url_for('index', lang_code=locale))
 
 @app.route('/robots.txt')
 def robots():


### PR DESCRIPTION
### Description:

- The problem is that english speakers should default to land on the root route `"/"` (without locale in url)
- The solution was to check for locale membership in DEFAULT_LANGUAGES (ENGLISH)
- This allows all english speakers (including en_GB) to share links without issues and get a prettier and more standard default URL
