### PR TITLE
Remove but support '/en' in website URL

### DIFF
--- a/config/constants.py
+++ b/config/constants.py
@@ -43,6 +43,8 @@ GITHUB_KEY = dotenv.get('GITHUB_KEY')
 
 # Language option constants
 
+DEFAULT_LANGUAGES = ['en', 'en_US', 'en_GB']
+
 LANGUAGES = [
     'ar',
     'de',

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -12,9 +12,13 @@ from .factories import PresaleFactory, InterestFactory
 
 fake = Faker()
 
-
-def test_root_returns_302(client):
+def test_root_with_default_langs_returns_200(client):
     res = client.get(url_for('root'))
+    assert res.status_code == 200
+
+
+def test_root_without_default_lang_returns_302(client):
+    res = client.get(url_for('root'), headers={"Accept-Language": "fr"}   )
     assert res.status_code == 302
 
 

--- a/views/web_views.py
+++ b/views/web_views.py
@@ -42,7 +42,11 @@ def beforeRequest():
 
 @app.route('/')
 def root():
-    return redirect(url_for('index', lang_code=get_locale()))
+    locale = get_locale()
+    if locale and locale in constants.DEFAULT_LANGUAGES:
+        return render_template('index.html')
+    else:
+        return redirect(url_for('index', lang_code=locale))
 
 @app.route('/robots.txt')
 def robots():


### PR DESCRIPTION
This fixes issue #210 

### Checklist:

- Ran tests
- No readme updates

### Description:

Please explain the changes you made here:

- Solves removing '/en' for default english speakers
- Solution is to allow english users to get "/" in URL by default via a DEFAULT_LANGUAGES constant

