### PR TITLE
Add rate limiting for Flask backend

### DIFF
--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -35,9 +35,11 @@ http {
 	upstream app_server {
 		server unix:/tmp/nginx.socket fail_timeout=0;
 	}
-	
+
 	proxy_cache_path /tmp/cache levels=1:2 keys_zone=my_cache:10m max_size=200m
 	                 inactive=120m use_temp_path=off;
+
+        limit_req_zone $binary_remote_addr zone=flask:10m rate=10r/s;
 
 	server {
 		listen <%= ENV["PORT"] %>;
@@ -53,7 +55,7 @@ http {
 			proxy_set_header Host $http_host;
 			proxy_redirect off;
 			proxy_pass http://app_server;
-			
+
 			proxy_cache my_cache;
 			proxy_cache_valid 200 120m;
 			add_header X-Proxy-Cache $upstream_cache_status;
@@ -64,7 +66,7 @@ http {
 			alias /app/static/;
 			expires 20m;
 			add_header Cache-Control public;
-			
+
 			gzip on;
 			gzip_disable "msie6";
 			gzip_vary on;
@@ -77,11 +79,12 @@ http {
 		}
 
 		location / {
+                        limit_rez zone=flask burst=20;
 			proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 			proxy_set_header Host $http_host;
 			proxy_redirect off;
 			proxy_pass http://app_server;
-			
+
 
 			# Cache proxied pages that have a language code
 			location ~ ^/([a-z][a-z]|zh_Hans|zh_Hant)(/.*)?$ {
@@ -89,11 +92,11 @@ http {
 				proxy_set_header Host $http_host;
 				proxy_redirect off;
 				proxy_pass http://app_server;
-				
+
 				proxy_cache my_cache;
 				proxy_cache_valid 200 120m;
 				# No caching if the user has session data (for example  an upcoming flash message)
-				proxy_cache_bypass $cookie_SESSION; 
+				proxy_cache_bypass $cookie_SESSION;
 				add_header X-Proxy-Cache $upstream_cache_status;
 			}
 		}

--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -39,7 +39,7 @@ http {
 	proxy_cache_path /tmp/cache levels=1:2 keys_zone=my_cache:10m max_size=200m
 	                 inactive=120m use_temp_path=off;
 
-        limit_req_zone $binary_remote_addr zone=flask:10m rate=10r/s;
+	limit_req_zone $binary_remote_addr zone=flask:10m rate=10r/s;
 
 	server {
 		listen <%= ENV["PORT"] %>;
@@ -79,7 +79,7 @@ http {
 		}
 
 		location / {
-                        limit_rez zone=flask burst=20;
+			limit_req zone=flask burst=20;
 			proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 			proxy_set_header Host $http_host;
 			proxy_redirect off;


### PR DESCRIPTION
First pull request? Read our [guide to contributing](https://docs.originprotocol.com/#contributing)

### Checklist:

- [x] Test your work and double check you didn't break anything
- [x] Update the README, if necessary

### Description:

- Adds rate limit of 10req/s for endpoints that hit the Flask backend. This should be a reasonable value. It doesn't apply to static assets like images
- Fixed some white spacing
