### PR TITLE
Origin Rewards Redirect

### DIFF
--- a/config/universal.py
+++ b/config/universal.py
@@ -17,8 +17,6 @@ CONTACT_EMAIL = 'info@originprotocol.com'
 PRODUCT_BRIEF_URL = BASE_URL + '/product-brief'
 WHITEPAPER_URL = BASE_URL + '/whitepaper'
 
-DEMO_DAPP_URL = 'https://demo.originprotocol.com'
-
 GITHUB_URL = 'https://github.com/originprotocol'
 SLACK_URL = 'https://slack.originprotocol.com/'
 DISCORD_URL = 'https://discord.gg/jyxpUSe'
@@ -28,6 +26,7 @@ FACEBOOK_URL = 'https://www.facebook.com/originprotocol'
 IOS_URL = 'https://itunes.apple.com/app/origin-wallet/id1446091928'
 ANDROID_URL = 'https://play.google.com/store/apps/details?id=com.origincatcher'
 DAPP_URL = 'https://dapp.originprotocol.com'
+REWARDS_URL = 'https://dapp.originprotocol.com/#/welcome'
 FAUCET_URL = 'https://faucet.originprotocol.com'
 
 DEFAULT_SHARE_MSG = quote('Check out ' + BUSINESS_NAME + ', an exciting blockchain project that will decentralize the sharing economy.')

--- a/views/web_views.py
+++ b/views/web_views.py
@@ -241,7 +241,7 @@ def dapp():
 
 @app.route('/rewards')
 @app.route('/<lang_code>/rewards')
-def dapp():
+def rewards():
     return redirect(universal.REWARDS_URL, code=301)
 
 @app.route('/partners')

--- a/views/web_views.py
+++ b/views/web_views.py
@@ -237,7 +237,12 @@ def telegram():
 @app.route('/dapp')
 @app.route('/<lang_code>/dapp')
 def dapp():
-    return redirect(universal.DAPP_URL, code=301) 
+    return redirect(universal.DAPP_URL, code=301)
+
+@app.route('/rewards')
+@app.route('/<lang_code>/rewards')
+def dapp():
+    return redirect(universal.REWARDS_URL, code=301)
 
 @app.route('/partners')
 @app.route('/<lang_code>/partners')


### PR DESCRIPTION
### Checklist:

- [ ] Test your work and double check you didn't break anything 🤷‍♂️ 
- [ ] ~Update the README, if necessary~

### Description:

This attempts to redirect https://www.originprotocol.com/rewards to https://dapp.originprotocol.com/#/welcome. I'm not able to test locally because my docker-compose didn't immediately work, and I have to run to a meeting. There may have been a reason not to redirect already, but @jonhearty and @AustinVirts are asking for it. I don't think we can expect people to follow a lengthy DApp URL that is displayed on a presentation slide with a hash character in the middle of it.