### PR TITLE
Allow all origins on static files

### DIFF
--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -50,6 +50,7 @@ http {
 		location ~ ^/static/(css|js)/all_ {
 			expires 20m;
 			add_header Cache-Control public;
+			add_header Access-Control-Allow-Origin "*";
 
 			proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 			proxy_set_header Host $http_host;
@@ -66,6 +67,7 @@ http {
 			alias /app/static/;
 			expires 20m;
 			add_header Cache-Control public;
+			add_header Access-Control-Allow-Origin "*";
 
 			gzip on;
 			gzip_disable "msie6";


### PR DESCRIPTION
### Description:

Adds `add_header Access-Control-Allow-Origin "*";` for all static files.  If there's any objections, I can tighten this config up to only be partnerconf.

### Checklist:

- [ ] Test your work and double-check to confirm that you didn't break anything
- [ ] Update the README, if necessary
- [ ] Run [translation commands](https://github.com/OriginProtocol/origin-website/tree/master/translations#extract-newedited-english-strings-for-translation) if any strings are changed
