### PR TITLE
Add rate limiting to the email backfill script

### DIFF
--- a/logic/emails/mailing_list.py
+++ b/logic/emails/mailing_list.py
@@ -49,7 +49,7 @@ def unsubscribe_sendgrid_contact(email):
             "recipient_emails": [email]
         }
         response = sg_api.client.asm.groups._(unsubscribe_group).suppressions.post(request_body=data)
-    except Exception as e
+    except Exception as e:
         log('ERROR unsubscribe_sendgrid_contact:', type(e), e)
         return False
 

--- a/logic/emails/mailing_list.py
+++ b/logic/emails/mailing_list.py
@@ -37,7 +37,7 @@ def add_sendgrid_contact(email, full_name=None, country_code=None, dapp_user=Non
         }]
         response = sg_api.client.contactdb.recipients.post(request_body=data)
     except Exception as e:
-        log('Error:', type(e), e)
+        log('ERROR add_sendgrid_contact:', type(e), e)
         return False
 
 def unsubscribe_sendgrid_contact(email):
@@ -49,8 +49,8 @@ def unsubscribe_sendgrid_contact(email):
             "recipient_emails": [email]
         }
         response = sg_api.client.asm.groups._(unsubscribe_group).suppressions.post(request_body=data)
-    except Exception as e:
-        log('Error:', type(e), e)
+    except Exception as e
+        log('ERROR unsubscribe_sendgrid_contact:', type(e), e)
         return False
 
 # Inserts or updates an entry in the email_list table.
@@ -83,7 +83,7 @@ def add_contact(email, first_name, last_name, ip_addr, country_code):
             db.session.add(row)
         db.session.commit()
     except Exception as e:
-        log('Error:', type(e), e)
+        log('ERROR add_contact:', type(e), e)
         raise e
 
     return new_contact
@@ -113,7 +113,7 @@ def presale(full_name, email, desired_allocation, desired_allocation_currency, c
         db.session.add(me)
         db.session.commit()
     except Exception as e:
-        log('Error:', type(e), e)
+        log('ERROR presale:', type(e), e)
         return gettext('Ooops! Something went wrong.')
 
     if sending_addr:
@@ -148,7 +148,7 @@ def unsubscribe(email):
             me.unsubscribed = True
             db.session.commit()
     except Exception as e:
-        log('Error:', type(e), e)
+        log('ERROR unsubscribe:', type(e), e)
         return gettext('Ooops, something went wrong')
 
     return gettext('You have been unsubscribed')
@@ -181,7 +181,7 @@ def partners_interest(name, company_name, email, website, note, ip_addr):
         db.session.add(me)
         db.session.commit()
     except Exception as e:
-        log('Error:', type(e), e)
+        log('ERROR partners_interest:', type(e), e)
         return gettext('Ooops! Something went wrong.')
 
     message = "Name: %s<br>Company Name: %s<br>Email: %s<br>Website: %s<br>Note: %s" % (name, company_name,

--- a/logic/scripts/backfill_dapp_identity.py
+++ b/logic/scripts/backfill_dapp_identity.py
@@ -8,9 +8,16 @@ import csv
 import requests
 import sys
 
+from time import sleep
+
 PROD_URL = 'https://www.originprotocol.com/mailing-list/join'
 STAGING_URL='https://staging.originprotocol.com/mailing-list/join'
 LOCAL_URL = 'http://localhost:5000/mailing-list/join'
+
+# Rate limite the number of requests made to the mailing-list/jin endpoint to ~1 per sec.
+# This is necessary since internally that endpoint makes calls to the
+# SendGrid /contactdb/recipients API which itself is rate limited.
+SLEEP_SEC = 0.9 # 0.9 second
 
 def process(url, eth_address, email, first_name, last_name, phone, country_code, ip):
     print('Adding entry %s %s' % (email, eth_address))
@@ -22,7 +29,8 @@ def process(url, eth_address, email, first_name, last_name, phone, country_code,
         'phone': phone,
         'country_code': country_code,
         'ip_addr': ip,
-        'dapp_user': 1
+        'dapp_user': 1,
+        'backfill': 1
     }
     response = requests.post(url=url, data=data)
     data = response.json()
@@ -70,6 +78,11 @@ def main(filename, url, do_it):
                 num_success += 1
             else:
                 num_failure += 1
+            print('%d entries processed' % num)
+
+            # Sleep before processing the next entry for rate limiting purposes.
+            sleep(SLEEP_SEC)
+
     print('Processed %d entries. %s skipped %d successes %d failures' % (num, num_skip, num_success, num_failure))
 
 if __name__ == '__main__':

--- a/logic/scripts/backfill_dapp_identity.py
+++ b/logic/scripts/backfill_dapp_identity.py
@@ -17,7 +17,7 @@ LOCAL_URL = 'http://localhost:5000/mailing-list/join'
 # Rate limite the number of requests made to the mailing-list/jin endpoint to ~1 per sec.
 # This is necessary since internally that endpoint makes calls to the
 # SendGrid /contactdb/recipients API which itself is rate limited.
-SLEEP_SEC = 0.9 # 0.9 second
+SLEEP_SEC = 1.0 # 1 sec
 
 def process(url, eth_address, email, first_name, last_name, phone, country_code, ip):
     print('Adding entry %s %s' % (email, eth_address))

--- a/views/web_views.py
+++ b/views/web_views.py
@@ -213,7 +213,7 @@ def join_mailing_list():
 
         # Add the entry to the Sendgrid contact list.
         if new_contact:
-            log('Add to Sendgrid contact list')
+            log('Adding to Sendgrid contact list')
             mailing_list.add_sendgrid_contact(
                 email=email,
                 full_name=full_name,


### PR DESCRIPTION

### Description:

- Added rate limiting to the backfill script to avoid hitting the SendGrid contact API rate limiting.
- Do not send a welcome email for contacts added via backfill script since those accounts were created a while back the user would likely have no clue why they received a welcome email now.

### Checklist:

- [X] Test your work and double-check to confirm that you didn't break anything
- [ ] Update the README, if necessary
- [ ] Run [translation commands](https://github.com/OriginProtocol/origin-website/tree/master/translations#extract-newedited-english-strings-for-translation) if any strings are changed
