### PR TITLE
Update token page title and description to include OGN

### DIFF
--- a/templates/ogn-token.html
+++ b/templates/ogn-token.html
@@ -1,8 +1,8 @@
 {% extends 'base.html' %}
 
-{% block title %}{{ gettext("Origin Protocol - Build on Origin") }}{% endblock %}
+{% block title %}{{ gettext("OGN: Origin Protocol Token") }}{% endblock %}
 
-{% block meta_description %}{{ gettext("Origin Protocol - Build on Origin") }}{% endblock %}
+{% block meta_description %}{{ gettext("OGN: Origin Protocol Token") }}{% endblock %}
 
 {% block content %}
 

--- a/templates/ogn-token.html
+++ b/templates/ogn-token.html
@@ -1,8 +1,8 @@
 {% extends 'base.html' %}
 
-{% block title %}{{ gettext("OGN: Origin Protocol Token") }}{% endblock %}
+{% block title %}{{ gettext("Origin Protocol - OGN Token") }}{% endblock %}
 
-{% block meta_description %}{{ gettext("OGN: Origin Protocol Token") }}{% endblock %}
+{% block meta_description %}{{ gettext("Origin Protocol - OGN Token") }}{% endblock %}
 
 {% block content %}
 


### PR DESCRIPTION
First pull request? Read our [guide to contributing](https://docs.originprotocol.com/#contributing)

### Description:

Add OGN to the title and description for the page https://www.originprotocol.com/ogn-token
I'm terrible at marketing so please let me know if you have better copies for the text to use as title/description...

We could take this further and add OGN to more pages. Perhaps the ones with the highest traffic like landing page and whitepaper pages? Happy to do that too but please help with copies. Here are the current copies for those 2 pages:
 - landing page
    - title: "Origin Protocol"
    - description: "The sharing economy without intermediaries. Origin is a protocol for creating sharing economy marketplaces using the Ethereum blockchain and IPFS."
 - whitepaper
    - title: "Origin Protocol"
    - description: ""Origin Protocol - Whitepaper"


### Checklist:

- [ ] Test your work and double-check to confirm that you didn't break anything
- [ ] Update the README, if necessary
- [ ] Run [translation commands](https://github.com/OriginProtocol/origin-website/tree/master/translations#extract-newedited-english-strings-for-translation) if any strings are changed
