### PR TITLE
do not allow website to be loaded inside iframe on another site

### DIFF
--- a/views/web_views.py
+++ b/views/web_views.py
@@ -83,6 +83,10 @@ def beforeRequest():
     )
     g.metadata["url"] = "https://www.originprotocol.com"
 
+@app.after_request
+def after_request(response):
+    response.headers["X-Frame-Options"] = "SAMEORIGIN"
+    return response
 
 @app.route("/", strict_slashes=False)
 def root():


### PR DESCRIPTION
Do not allow the website to be loaded inside an iFrame on another site

### Checklist:

- [ ] Test your work and double-check to confirm that you didn't break anything
- [ ] Update the README, if necessary
- [ ] Run [translation commands](https://github.com/OriginProtocol/origin-website/tree/master/translations#extract-newedited-english-strings-for-translation) if any strings are changed
