### PR TITLE
Disable CORS on all routes but mailing list

### DIFF
--- a/views/web_views.py
+++ b/views/web_views.py
@@ -6,7 +6,7 @@ import sys
 import calendar
 import random
 
-from flask_cors import CORS, cross_origin
+from flask_cors import cross_origin
 from app import app
 from database import db, db_models
 
@@ -45,7 +45,6 @@ from logic.scripts import token_stats, drops
 # Translation: change path of messages.mo files
 app.config["BABEL_TRANSLATION_DIRECTORIES"] = "../translations"
 babel = Babel(app)
-cors = CORS(app)
 app.config['CORS_HEADERS'] = 'Content-Type'
 
 recaptcha = ReCaptcha(app=app)


### PR DESCRIPTION
We currently have CORS enabled for all of the origin-website. It looks like what we intended was to just enable it for the mailing list route.

Looking at the [docs](https://flask-cors.readthedocs.io/en/latest/) on flask cors, it looks like doing `CORS(app)` is only needed if enabling cors for the entire site. The per route `@cross_origin()` should work fine without it.

I've not tested this, nor am I 100% there is nothing else that needs CORS protection, so I am passing it to @sparrowDom for review and sanity checking. Thanks!