### PR TITLE
fix ogv endpoint

### DIFF
--- a/logic/scripts/token_stats.py
+++ b/logic/scripts/token_stats.py
@@ -487,7 +487,7 @@ def compute_ogv_stats():
 
     token_prices = fetch_token_prices()
 
-    ogv_supply_stats = fetch_ogn_stats(
+    ogv_supply_stats = fetch_ogv_stats(
         token_prices["ogv_usd_price"]
     )
 


### PR DESCRIPTION
quick ogv endpoint fix to call `fetch_ogv_stats` instead of `fetch_ogn_stats`